### PR TITLE
Modified SConstruct.

### DIFF
--- a/src/systems_of_equations_ex4/SConstruct
+++ b/src/systems_of_equations_ex4/SConstruct
@@ -1,5 +1,4 @@
 # Set environment variable LIBMESH_ROOT or execute scons like that: scons LIBMESH_ROOT=$HOME/software/libmesh scons  
-# Start resulting executable like that: LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/software/libmesh/.libs ./fem-shell [...]
 
 import os
 
@@ -9,12 +8,15 @@ conf = Configure(env)
 
 libmeshRoot = os.getenv('LIBMESH_ROOT')
 
-env.Append(CPPPATH = [os.path.join(libmeshRoot, 'include')])
-env.Append(LIBPATH = [os.path.join(libmeshRoot, ".libs")])
+env.Append(CPPPATH = [os.path.join(libmeshRoot, 'include'),
+                      "/usr/include/vtk-6.1"])
+env.Append(LIBPATH = [os.path.join(libmeshRoot, "lib")])
 
 conf.CheckLib("mesh_opt")
 
 env["CXX"] = 'mpicxx'
 env.Append(CCFLAGS = ["-g3", "-O0", "-Wall", "-std=c++11", '-fopenmp'])
+
+env.Append(LINKFLAGS = ['-Wl,-rpath,' + os.path.join(libmeshRoot, "lib")])
 
 env.Program('fem-shell', ['systems_of_equations_ex4.cpp'])


### PR DESCRIPTION
LD_LIBRARY_PATH is not needed anymore.
LIBMESH_ROOT should be like /usr/local, directory where lib and include
directories reside.
